### PR TITLE
PATCH: Fix Clang compiler flag macro #1

### DIFF
--- a/src/util/pext.hpp
+++ b/src/util/pext.hpp
@@ -9,7 +9,7 @@
 #define SHAK_PEXTABLE
 // gcc
 #include <x86gprintrin.h>
-#elif defined(__clang__) && !(defined(_MSC_VER) || defined(__SCE__)) || __has_feature(modules) || \
+#elif defined(__clang__) && !(defined(_MSC_VER) || defined(__SCE__)) || \
     defined(__BMI2__)
 #define SHAK_PEXTABLE
 // clang


### PR DESCRIPTION
Fixed a bug where a Clang compile macro was used in a possibly error-prone context. Should help resolve #1.